### PR TITLE
Add flag to specify the URL path

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Usage of spark:
   -key="key.pem": SSL private Key path
   -sslPort="10433": SSL listening port
   -status=200: Returned HTTP status code
+  -path="/": URL path
 
 ```
 


### PR DESCRIPTION
This patch allows spark to be used like this:
`$ spark -path '/hello' '<p>Hello world!</p>'`
`Serving <p>Hello world!</p> on 0.0.0.0:8080/mypath...`
or
`$ spark -path '/hello/' .`
`Serving . on 0.0.0.0:8080/mypath/...`